### PR TITLE
fixed code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Do negative sampling and dump the whole training and validation data:
 ```bash
 python KGpreprocess.py --dumpPath KE1 \
 		-ns 1 \
-		-ent_desc Qdesc.bpe \
+		--ent_desc Qdesc.bpe \
 		--train train.txt \
 		--valid valid.txt
 ```


### PR DESCRIPTION
Hi, I've noticed a little typo in the readme file.

This PR fixes a typo in the Readme file. KGpreprocess.py expects `ent_desc` to be prepended with 2 hyphens, not 1.

Thanks, 
Michal